### PR TITLE
Bump nodejs version in deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
According to [node release schedule](https://nodejs.org/en/about/releases/), v15 is no longer supported. Instead, I figured that moving to LTS version is probably the best call.
