### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ function githubIssueLinks(options) {
     return {
       type: "link",
       title: null,
-      url: `${baseRepoUrl}/issues/${value.substr(1)}`,
+      url: `${baseRepoUrl}/issues/${value.slice(1)}`,
       children: [{ type: "text", value }],
     };
   }

--- a/pages/client_login.js
+++ b/pages/client_login.js
@@ -41,9 +41,9 @@ export default function ClientLogin() {
       return;
     }
 
-    const oauthHash = location.hash.substr(1);
+    const oauthHash = location.hash.slice(1);
     const oauthToken = oauthHash
-      .substr(oauthHash.indexOf("access_token="))
+      .slice(oauthHash.indexOf("access_token="))
       .split("&")[0]
       .split("=")[1];
     if (oauthToken) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.