### PR TITLE
Fix Tailwind v3 deprecations

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
     extend: {
       colors: {
         gray: {
-          ...colors.trueGray,
+          ...colors.neutral,
           900: "#1A1919",
           800: "#252424",
           700: "#2F2D2D",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-  purge: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,6 @@ const colors = require("tailwindcss/colors");
 
 module.exports = {
   purge: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
-  darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
- darkMode is now enabled by default
  https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration
- purge key changed to content due to Tailwind not using PurgeCSS under the hood
  https://tailwindcss.com/docs/upgrade-guide#configure-content-sources
- gray scales have been renamed, trueGray is now called neutral
  https://tailwindcss.com/docs/upgrade-guide#renamed-gray-scales
