### PR TITLE
Add announce and whispers API scopes

### DIFF
--- a/pages/client_login.js
+++ b/pages/client_login.js
@@ -29,6 +29,8 @@ const scopes = [
   "channel:read:polls", // for reading broadcaster poll status
   "channel:manage:predictions", // for creating & ending predictions
   "channel:read:predictions", // for reading broadcaster prediction status
+  "moderator:manage:announcements", // for announce api
+  "user:manage:whispers", // for whispers api
 ];
 
 export default function ClientLogin() {


### PR DESCRIPTION
Adds `moderator:manage:announcements` for a future /announce color options possibility. Adds `user:manage:whispers` so now new-ish (post-2019) users can send whispers maybe (except they have to give up their data). 