### PR TITLE
Update & Cleanup scopes

### DIFF
--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -20,28 +20,33 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#create-clip
   "clips:edit", // for /clip creation 
 
-  // https://dev.twitch.tv/docs/api/reference#create-stream-marker https://dev.twitch.tv/docs/api/reference#modify-channel-information
+  // https://dev.twitch.tv/docs/api/reference#create-stream-marker 
+  // https://dev.twitch.tv/docs/api/reference#modify-channel-information
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
 
   // https://dev.twitch.tv/docs/api/reference#get-user-block-list
   "user:read:blocked_users", // for getting list of blocked users 
 
-  // https://dev.twitch.tv/docs/api/reference#block-user https://dev.twitch.tv/docs/api/reference#unblock-user
+  // https://dev.twitch.tv/docs/api/reference#block-user 
+  // https://dev.twitch.tv/docs/api/reference#unblock-user
   "user:manage:blocked_users", // for blocking/unblocking other users
 
   // https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
   "moderator:manage:automod", // for approving/denying automod messages 
 
-  // https://dev.twitch.tv/docs/api/reference#start-a-raid https://dev.twitch.tv/docs/api/reference#cancel-a-raid
+  // https://dev.twitch.tv/docs/api/reference#start-a-raid 
+  // https://dev.twitch.tv/docs/api/reference#cancel-a-raid
   "channel:manage:raids", // for starting/canceling raids
 
-  // https://dev.twitch.tv/docs/api/reference#create-poll https://dev.twitch.tv/docs/api/reference#end-poll
+  // https://dev.twitch.tv/docs/api/reference#create-poll 
+  // https://dev.twitch.tv/docs/api/reference#end-poll
   "channel:manage:polls", // for creating & ending polls (not currently used)
 
   // https://dev.twitch.tv/docs/api/reference#get-polls
   "channel:read:polls", // for reading broadcaster poll status (not currently used) 
 
-  // https://dev.twitch.tv/docs/api/reference#create-prediction https://dev.twitch.tv/docs/api/reference#end-prediction
+  // https://dev.twitch.tv/docs/api/reference#create-prediction 
+  // https://dev.twitch.tv/docs/api/reference#end-prediction
   "channel:manage:predictions", // for creating & ending predictions (not currently used)
 
   // https://dev.twitch.tv/docs/api/reference#get-predictions
@@ -53,7 +58,8 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#send-whisper
   "user:manage:whispers", // for whispers api 
 
-  // https://dev.twitch.tv/docs/api/reference#ban-user https://dev.twitch.tv/docs/api/reference#unban-user
+  // https://dev.twitch.tv/docs/api/reference#ban-user 
+  // https://dev.twitch.tv/docs/api/reference#unban-user
   "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api 
   
   // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
@@ -65,10 +71,14 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#get-chat-settings
   "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow)
 
-  // https://dev.twitch.tv/docs/api/reference#get-moderators https://dev.twitch.tv/docs/api/reference#add-channel-moderator https://dev.twitch.tv/docs/api/reference#remove-channel-vip
+  // https://dev.twitch.tv/docs/api/reference#get-moderators 
+  // https://dev.twitch.tv/docs/api/reference#add-channel-moderator 
+  // https://dev.twitch.tv/docs/api/reference#remove-channel-vip
   "channel:manage:moderators", // for add/remove/view mod api
 
-  // https://dev.twitch.tv/docs/api/reference#add-channel-vip https://dev.twitch.tv/docs/api/reference#remove-channel-vip https://dev.twitch.tv/docs/api/reference#get-vips 
+  // https://dev.twitch.tv/docs/api/reference#add-channel-vip 
+  // https://dev.twitch.tv/docs/api/reference#remove-channel-vip 
+  // https://dev.twitch.tv/docs/api/reference#get-vips 
   "channel:manage:vips", // for add/remove/view vip api
 
   // https://dev.twitch.tv/docs/api/reference#get-chatters

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -6,12 +6,12 @@ const redirectUrl = process.env.NEXT_PUBLIC_TWITCH_OAUTH_REDIRECT_URL!;
 const twitchClientID = process.env.NEXT_PUBLIC_TWITCH_OAUTH_CLIENT_ID!;
 const scopes = [
   "channel_editor", // for /raid
-  "channel:moderate",
-  "channel:read:redemptions",
-  "chat:edit",
-  "chat:read",
-  "whispers:read",
-  "whispers:edit",
+  "channel:moderate", // for seeing automod & which moderator banned/unbanned a user (felanbird unbanned weeb123)
+  "channel:read:redemptions", // for getting the list of channel point redemptions
+  "chat:edit", // for sending messages in chat
+  "chat:read", // for viewing messages in chat
+  "whispers:read", // for viewing recieved whispers
+  "whispers:edit", // for sending whispers
   "channel_commercial", // for /commercial
   "channel:edit:commercial", // in case twitch upgrades things in the future (and this scope is required)
   "clips:edit", // for clip creation

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -15,31 +15,45 @@ const scopes = [
   "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
   "channel:edit:commercial", // for /commercial api https://dev.twitch.tv/docs/api/reference#start-commercial
   "clips:edit", // for /clip creation https://dev.twitch.tv/docs/api/reference#create-clip
+
   // https://dev.twitch.tv/docs/api/reference#create-stream-marker https://dev.twitch.tv/docs/api/reference#modify-channel-information
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
+
   "user:read:blocked_users", // for getting list of blocked users https://dev.twitch.tv/docs/api/reference#get-user-block-list
+
   // https://dev.twitch.tv/docs/api/reference#block-user https://dev.twitch.tv/docs/api/reference#unblock-user
   "user:manage:blocked_users", // for blocking/unblocking other users
+
   "moderator:manage:automod", // for approving/denying automod messages https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
+
   // https://dev.twitch.tv/docs/api/reference#start-a-raid https://dev.twitch.tv/docs/api/reference#cancel-a-raid
   "channel:manage:raids", // for starting/canceling raids
+
   // https://dev.twitch.tv/docs/api/reference#create-poll https://dev.twitch.tv/docs/api/reference#end-poll
   "channel:manage:polls", // for creating & ending polls (not currently used)
+
   "channel:read:polls", // for reading broadcaster poll status (not currently used) https://dev.twitch.tv/docs/api/reference#get-polls
+
   // https://dev.twitch.tv/docs/api/reference#create-prediction https://dev.twitch.tv/docs/api/reference#end-prediction
   "channel:manage:predictions", // for creating & ending predictions (not currently used)
+
   "channel:read:predictions", // for reading broadcaster prediction status (not currently used) https://dev.twitch.tv/docs/api/reference#get-predictions
   "moderator:manage:announcements", // for /announce api https://dev.twitch.tv/docs/api/reference#send-chat-announcement
   "user:manage:whispers", // for whispers api https://dev.twitch.tv/docs/api/reference#send-whisper
+
   // https://dev.twitch.tv/docs/api/reference#ban-user https://dev.twitch.tv/docs/api/reference#unban-user
   "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api 
+
   "moderator:manage:chat_messages", // for delete message api (/delete, /clear) https://dev.twitch.tv/docs/api/reference#delete-chat-messages
   "user:manage:chat_color", // for update user color api (/color coral) https://dev.twitch.tv/docs/api/reference#update-user-chat-color
   "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow) https://dev.twitch.tv/docs/api/reference#get-chat-settings
+
   // https://dev.twitch.tv/docs/api/reference#get-moderators https://dev.twitch.tv/docs/api/reference#add-channel-moderator https://dev.twitch.tv/docs/api/reference#remove-channel-vip
   "channel:manage:moderators", // for add/remove/view mod api
+
   // https://dev.twitch.tv/docs/api/reference#add-channel-vip https://dev.twitch.tv/docs/api/reference#remove-channel-vip https://dev.twitch.tv/docs/api/reference#get-vips 
   "channel:manage:vips", // for add/remove/view vip api
+
   "moderator:read:chatters", // for get chatters
   "moderator:read:chatters", // for get chatters api (not currently used) https://dev.twitch.tv/docs/api/reference#get-chatters
 ];

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -7,7 +7,7 @@ const twitchClientID = process.env.NEXT_PUBLIC_TWITCH_OAUTH_CLIENT_ID!;
 const scopes = [
   "channel_editor", // for /raid, will be deprecated on or before Feb 18th 2023, already using "channel:manage:raids"
   "channel:moderate", // for seeing automod & which moderator banned/unbanned a user (felanbird unbanned weeb123)
-  "channel:read:redemptions", // for getting the list of channel point redemptions
+  "channel:read:redemptions", // for getting the list of channel point redemptions (not currently used)
   "chat:edit", // for sending messages in chat
   "chat:read", // for viewing messages in chat
   "whispers:read", // for viewing recieved whispers
@@ -20,10 +20,10 @@ const scopes = [
   "user:manage:blocked_users", // for blocking/unblocking other users
   "moderator:manage:automod", // for approving/denying automod messages
   "channel:manage:raids", // for starting/canceling raids
-  "channel:manage:polls", // for creating & ending polls
-  "channel:read:polls", // for reading broadcaster poll status
-  "channel:manage:predictions", // for creating & ending predictions
-  "channel:read:predictions", // for reading broadcaster prediction status
+  "channel:manage:polls", // for creating & ending polls (not currently used)
+  "channel:read:polls", // for reading broadcaster poll status (not currently used)
+  "channel:manage:predictions", // for creating & ending predictions (not currently used)
+  "channel:read:predictions", // for reading broadcaster prediction status (not currently used)
   "moderator:manage:announcements", // for announce api
   "user:manage:whispers", // for whispers api
   "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api
@@ -33,6 +33,7 @@ const scopes = [
   "channel:manage:moderators", // for add/remove mod api
   "channel:manage:vips", // for add/remove vip api
   "moderator:read:chatters", // for get chatters
+  "moderator:read:chatters", // for get chatters api (not currently used)
 ];
 
 export default function ClientLogin() {

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -5,10 +5,6 @@ import Section from "../components/section";
 const redirectUrl = process.env.NEXT_PUBLIC_TWITCH_OAUTH_REDIRECT_URL!;
 const twitchClientID = process.env.NEXT_PUBLIC_TWITCH_OAUTH_CLIENT_ID!;
 const scopes = [
-  "user_subscriptions",
-  "user_blocks_edit", // deprecated, replaced with "user:manage:blocked_users"
-  "user_blocks_read", // deprecated, replaced with "user:read:blocked_users"
-  "user_follows_edit", // deprecated, soon to be removed later since we now use "user:edit:follows"
   "channel_editor", // for /raid
   "channel:moderate",
   "channel:read:redemptions",
@@ -18,7 +14,6 @@ const scopes = [
   "whispers:edit",
   "channel_commercial", // for /commercial
   "channel:edit:commercial", // in case twitch upgrades things in the future (and this scope is required)
-  "user:edit:follows", // for (un)following
   "clips:edit", // for clip creation
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
   "user:read:blocked_users", // for getting list of blocked users

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -13,27 +13,35 @@ const scopes = [
   "whispers:read", // for viewing recieved whispers
   "whispers:edit", // for sending whispers, will be deprecated on or before Feb 18th 2023, already using "user:manage:whispers"
   "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
-  "channel:edit:commercial", // for /commercial api
-  "clips:edit", // for /clip creation
+  "channel:edit:commercial", // for /commercial api https://dev.twitch.tv/docs/api/reference#start-commercial
+  "clips:edit", // for /clip creation https://dev.twitch.tv/docs/api/reference#create-clip
+  // https://dev.twitch.tv/docs/api/reference#create-stream-marker https://dev.twitch.tv/docs/api/reference#modify-channel-information
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
-  "user:read:blocked_users", // for getting list of blocked users
+  "user:read:blocked_users", // for getting list of blocked users https://dev.twitch.tv/docs/api/reference#get-user-block-list
+  // https://dev.twitch.tv/docs/api/reference#block-user https://dev.twitch.tv/docs/api/reference#unblock-user
   "user:manage:blocked_users", // for blocking/unblocking other users
-  "moderator:manage:automod", // for approving/denying automod messages
+  "moderator:manage:automod", // for approving/denying automod messages https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
+  // https://dev.twitch.tv/docs/api/reference#start-a-raid https://dev.twitch.tv/docs/api/reference#cancel-a-raid
   "channel:manage:raids", // for starting/canceling raids
+  // https://dev.twitch.tv/docs/api/reference#create-poll https://dev.twitch.tv/docs/api/reference#end-poll
   "channel:manage:polls", // for creating & ending polls (not currently used)
-  "channel:read:polls", // for reading broadcaster poll status (not currently used)
+  "channel:read:polls", // for reading broadcaster poll status (not currently used) https://dev.twitch.tv/docs/api/reference#get-polls
+  // https://dev.twitch.tv/docs/api/reference#create-prediction https://dev.twitch.tv/docs/api/reference#end-prediction
   "channel:manage:predictions", // for creating & ending predictions (not currently used)
-  "channel:read:predictions", // for reading broadcaster prediction status (not currently used)
-  "moderator:manage:announcements", // for /announce api
-  "user:manage:whispers", // for whispers api
-  "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api
-  "moderator:manage:chat_messages", // for delete message api (/delete, /clear)
-  "user:manage:chat_color", // for update user color api (/color coral)
+  "channel:read:predictions", // for reading broadcaster prediction status (not currently used) https://dev.twitch.tv/docs/api/reference#get-predictions
+  "moderator:manage:announcements", // for /announce api https://dev.twitch.tv/docs/api/reference#send-chat-announcement
+  "user:manage:whispers", // for whispers api https://dev.twitch.tv/docs/api/reference#send-whisper
+  // https://dev.twitch.tv/docs/api/reference#ban-user https://dev.twitch.tv/docs/api/reference#unban-user
+  "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api 
+  "moderator:manage:chat_messages", // for delete message api (/delete, /clear) https://dev.twitch.tv/docs/api/reference#delete-chat-messages
+  "user:manage:chat_color", // for update user color api (/color coral) https://dev.twitch.tv/docs/api/reference#update-user-chat-color
   "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow) https://dev.twitch.tv/docs/api/reference#get-chat-settings
+  // https://dev.twitch.tv/docs/api/reference#get-moderators https://dev.twitch.tv/docs/api/reference#add-channel-moderator https://dev.twitch.tv/docs/api/reference#remove-channel-vip
   "channel:manage:moderators", // for add/remove/view mod api
+  // https://dev.twitch.tv/docs/api/reference#add-channel-vip https://dev.twitch.tv/docs/api/reference#remove-channel-vip https://dev.twitch.tv/docs/api/reference#get-vips 
   "channel:manage:vips", // for add/remove/view vip api
   "moderator:read:chatters", // for get chatters
-  "moderator:read:chatters", // for get chatters api (not currently used)
+  "moderator:read:chatters", // for get chatters api (not currently used) https://dev.twitch.tv/docs/api/reference#get-chatters
 ];
 
 export default function ClientLogin() {

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -5,15 +5,15 @@ import Section from "../components/section";
 const redirectUrl = process.env.NEXT_PUBLIC_TWITCH_OAUTH_REDIRECT_URL!;
 const twitchClientID = process.env.NEXT_PUBLIC_TWITCH_OAUTH_CLIENT_ID!;
 const scopes = [
-  "channel_editor", // for /raid
+  "channel_editor", // for /raid, will be deprecated on or before Feb 18th 2023, already using "channel:manage:raids"
   "channel:moderate", // for seeing automod & which moderator banned/unbanned a user (felanbird unbanned weeb123)
   "channel:read:redemptions", // for getting the list of channel point redemptions
   "chat:edit", // for sending messages in chat
   "chat:read", // for viewing messages in chat
   "whispers:read", // for viewing recieved whispers
-  "whispers:edit", // for sending whispers
-  "channel_commercial", // for /commercial
-  "channel:edit:commercial", // in case twitch upgrades things in the future (and this scope is required)
+  "whispers:edit", // for sending whispers, will be deprecated on or before Feb 18th 2023, already using "user:manage:whispers"
+  "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
+  "channel:edit:commercial", // for /commercial api
   "clips:edit", // for clip creation
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
   "user:read:blocked_users", // for getting list of blocked users

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -14,7 +14,7 @@ const scopes = [
   "whispers:edit", // for sending whispers, will be deprecated on or before Feb 18th 2023, already using "user:manage:whispers"
   "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
   "channel:edit:commercial", // for /commercial api
-  "clips:edit", // for clip creation
+  "clips:edit", // for /clip creation
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
   "user:read:blocked_users", // for getting list of blocked users
   "user:manage:blocked_users", // for blocking/unblocking other users
@@ -24,14 +24,14 @@ const scopes = [
   "channel:read:polls", // for reading broadcaster poll status (not currently used)
   "channel:manage:predictions", // for creating & ending predictions (not currently used)
   "channel:read:predictions", // for reading broadcaster prediction status (not currently used)
-  "moderator:manage:announcements", // for announce api
+  "moderator:manage:announcements", // for /announce api
   "user:manage:whispers", // for whispers api
   "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api
-  "moderator:manage:chat_messages", // for delete message api
-  "user:manage:chat_color", // for update user color api
-  "moderator:manage:chat_settings", // for roomstate api like followersonly
-  "channel:manage:moderators", // for add/remove mod api
-  "channel:manage:vips", // for add/remove vip api
+  "moderator:manage:chat_messages", // for delete message api (/delete, /clear)
+  "user:manage:chat_color", // for update user color api (/color coral)
+  "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow) https://dev.twitch.tv/docs/api/reference#get-chat-settings
+  "channel:manage:moderators", // for add/remove/view mod api
+  "channel:manage:vips", // for add/remove/view vip api
   "moderator:read:chatters", // for get chatters
   "moderator:read:chatters", // for get chatters api (not currently used)
 ];

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -54,7 +54,6 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#add-channel-vip https://dev.twitch.tv/docs/api/reference#remove-channel-vip https://dev.twitch.tv/docs/api/reference#get-vips 
   "channel:manage:vips", // for add/remove/view vip api
 
-  "moderator:read:chatters", // for get chatters
   "moderator:read:chatters", // for get chatters api (not currently used) https://dev.twitch.tv/docs/api/reference#get-chatters
 ];
 

--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -13,18 +13,24 @@ const scopes = [
   "whispers:read", // for viewing recieved whispers
   "whispers:edit", // for sending whispers, will be deprecated on or before Feb 18th 2023, already using "user:manage:whispers"
   "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
-  "channel:edit:commercial", // for /commercial api https://dev.twitch.tv/docs/api/reference#start-commercial
-  "clips:edit", // for /clip creation https://dev.twitch.tv/docs/api/reference#create-clip
+
+  // https://dev.twitch.tv/docs/api/reference#start-commercial
+  "channel:edit:commercial", // for /commercial api 
+
+  // https://dev.twitch.tv/docs/api/reference#create-clip
+  "clips:edit", // for /clip creation 
 
   // https://dev.twitch.tv/docs/api/reference#create-stream-marker https://dev.twitch.tv/docs/api/reference#modify-channel-information
   "channel:manage:broadcast", // for creating stream markers with /marker command, and for the /settitle and /setgame commands
 
-  "user:read:blocked_users", // for getting list of blocked users https://dev.twitch.tv/docs/api/reference#get-user-block-list
+  // https://dev.twitch.tv/docs/api/reference#get-user-block-list
+  "user:read:blocked_users", // for getting list of blocked users 
 
   // https://dev.twitch.tv/docs/api/reference#block-user https://dev.twitch.tv/docs/api/reference#unblock-user
   "user:manage:blocked_users", // for blocking/unblocking other users
 
-  "moderator:manage:automod", // for approving/denying automod messages https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
+  // https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages
+  "moderator:manage:automod", // for approving/denying automod messages 
 
   // https://dev.twitch.tv/docs/api/reference#start-a-raid https://dev.twitch.tv/docs/api/reference#cancel-a-raid
   "channel:manage:raids", // for starting/canceling raids
@@ -32,21 +38,32 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#create-poll https://dev.twitch.tv/docs/api/reference#end-poll
   "channel:manage:polls", // for creating & ending polls (not currently used)
 
-  "channel:read:polls", // for reading broadcaster poll status (not currently used) https://dev.twitch.tv/docs/api/reference#get-polls
+  // https://dev.twitch.tv/docs/api/reference#get-polls
+  "channel:read:polls", // for reading broadcaster poll status (not currently used) 
 
   // https://dev.twitch.tv/docs/api/reference#create-prediction https://dev.twitch.tv/docs/api/reference#end-prediction
   "channel:manage:predictions", // for creating & ending predictions (not currently used)
 
-  "channel:read:predictions", // for reading broadcaster prediction status (not currently used) https://dev.twitch.tv/docs/api/reference#get-predictions
-  "moderator:manage:announcements", // for /announce api https://dev.twitch.tv/docs/api/reference#send-chat-announcement
-  "user:manage:whispers", // for whispers api https://dev.twitch.tv/docs/api/reference#send-whisper
+  // https://dev.twitch.tv/docs/api/reference#get-predictions
+  "channel:read:predictions", // for reading broadcaster prediction status (not currently used) 
+
+  // https://dev.twitch.tv/docs/api/reference#send-chat-announcement
+  "moderator:manage:announcements", // for /announce api 
+
+  // https://dev.twitch.tv/docs/api/reference#send-whisper
+  "user:manage:whispers", // for whispers api 
 
   // https://dev.twitch.tv/docs/api/reference#ban-user https://dev.twitch.tv/docs/api/reference#unban-user
   "moderator:manage:banned_users", // for ban/unban/timeout/untimeout api 
+  
+  // https://dev.twitch.tv/docs/api/reference#delete-chat-messages
+  "moderator:manage:chat_messages", // for delete message api (/delete, /clear)
 
-  "moderator:manage:chat_messages", // for delete message api (/delete, /clear) https://dev.twitch.tv/docs/api/reference#delete-chat-messages
-  "user:manage:chat_color", // for update user color api (/color coral) https://dev.twitch.tv/docs/api/reference#update-user-chat-color
-  "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow) https://dev.twitch.tv/docs/api/reference#get-chat-settings
+  // https://dev.twitch.tv/docs/api/reference#update-user-chat-color
+  "user:manage:chat_color", // for update user color api (/color coral)
+
+  // https://dev.twitch.tv/docs/api/reference#get-chat-settings
+  "moderator:manage:chat_settings", // for roomstate api (/followersonly, /uniquechat, /slow)
 
   // https://dev.twitch.tv/docs/api/reference#get-moderators https://dev.twitch.tv/docs/api/reference#add-channel-moderator https://dev.twitch.tv/docs/api/reference#remove-channel-vip
   "channel:manage:moderators", // for add/remove/view mod api
@@ -54,7 +71,8 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#add-channel-vip https://dev.twitch.tv/docs/api/reference#remove-channel-vip https://dev.twitch.tv/docs/api/reference#get-vips 
   "channel:manage:vips", // for add/remove/view vip api
 
-  "moderator:read:chatters", // for get chatters api (not currently used) https://dev.twitch.tv/docs/api/reference#get-chatters
+  // https://dev.twitch.tv/docs/api/reference#get-chatters
+  "moderator:read:chatters", // for get chatters api (not currently used)
 ];
 
 export default function ClientLogin() {


### PR DESCRIPTION
This PR does the following:

1. Drops Kraken/Helix scopes that have been removed by Twitch: c03c82b
2. Adds comments to the scopes that were missing them: d2c32b6
3. Updates the comments for scopes soon to be deprecated: 28d4ba2
4. Adds comments stating which scopes are currently unused: ff34972
5. Updates a few existing comments: 7b55d8e
6. Adds Twitch documentation links to comments: a9e4817 bfeb344

Here's a side-by-side: that might be easier to read than all commits together:
https://github.com/chatterino/website/blob/main/pages/client_login.tsx
https://github.com/Felanbird/website/blob/chore/cleanup-scopes/pages/client_login.tsx

### notes
`channel:read:redemptions`
According to the [pubsub docs](https://dev.twitch.tv/docs/pubsub#available-topics): You are required to have this scope paired with `channel-points-channel-v1.<channel_id>` to see custom redemption, but this is in fact not the case; as I was able to see a custom redemption with only `chat:read`.
![image](https://user-images.githubusercontent.com/41973452/198725489-a0170499-e5af-4885-aa58-6dccc0bf8028.png)

According to the [helix docs](https://dev.twitch.tv/docs/api/reference#get-custom-reward): You are required to have this scope when you'd like to lookup the information of a custom reward, but we have no such function in Chatterino, so I've marked said scope as unused.
