### PR TITLE
Improve header layout on mobile

### DIFF
--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -37,7 +37,7 @@ function Nav() {
           <a href="/" className="no-underline">
             <div className="flex items-center text-white hover:text-blue-400 p-4 sm:p-6 space-x-4 sm:pr-0">
               <img src="logo.png" className="w-8 h-8" />
-              <div>Chatterino</div>
+              <div className="hidden sm:block">Chatterino</div>
             </div>
           </a>
 


### PR DESCRIPTION
# Screenshots
<p align="center">
<img height="400" alt="original" src="https://user-images.githubusercontent.com/98076988/213867467-9d1a6559-a068-4541-b16f-a693af69dab5.png">
<img height="400" alt="fixed" src="https://user-images.githubusercontent.com/98076988/213867482-1ca9db7c-26a5-4b5e-8999-21d1557821d9.png">
</p>

# Changes

- Hide the Chatterino text on screen width < 640px