### PR TITLE
Improve home page on mobile

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -293,8 +293,8 @@ function Miscellaneous() {
   return (
     <Section className="bg-gray-800">
       <div className="bg-gray-800 md:grid md:grid-cols-2 md:space-y-0">
-        <div className="p-16 space-y-4">
-          <div className="text-5xl">Visit the Wiki</div>
+        <div className="p-16 space-y-4 max-xs:p-6">
+          <div className="text-5xl max-xs:text-4xl">Visit the Wiki</div>
           <div>
             Find information on Chatterino's features and help documents for
             troubleshooting.
@@ -303,8 +303,8 @@ function Miscellaneous() {
             <Button className="ml-0 mt-6">Check It Out</Button>
           </a>
         </div>
-        <div className="p-16 space-y-4 bg-blue-500">
-          <div className="text-5xl">Check on the development</div>
+        <div className="p-16 space-y-4 bg-blue-500 max-xs:p-6">
+          <div className="text-5xl max-xs:text-4xl">Check on the development</div>
           <div>
             Chatterino is developed out in the open on our GitHub page. You can
             join the discussion or report issues there!

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,16 +198,16 @@ type TestimonialProps = {
 function Testimonial({ name, occupation, children, imgsrc }: TestimonialProps) {
   return (
     <div className="text-gray-400 bg-gray-900 p-8 m-8 rounded-lg text-left">
-      <div className="flex space-x-8">
+      <div className="flex space-x-8 max-xs:flex-col max-xs:space-x-0">
         <div
-          className="w-16 h-16 md:w-36 md:h-36 flex-shrink-0 rounded-full"
+          className="w-16 h-16 md:w-36 md:h-36 flex-shrink-0 rounded-full max-xs:self-center max-xs:mb-4"
           style={{
             backgroundImage: "url(" + imgsrc + ")",
             backgroundSize: "cover",
           }}
         />
         <div className="flex flex-col">
-          <div>{children}</div>
+          <div className="max-xs:mb-2">{children}</div>
           <div className="flex-grow" />
           <div className="text-xl text-white">{name}</div>
           <div className="text-sm text-white">{occupation}</div>
@@ -263,7 +263,7 @@ let testimonials = [
 function Testimonials() {
   return (
     <Section
-      className="p-6 md:p-12 bg-gray-800"
+      className="p-6 md:p-12 bg-gray-800 max-xs:p-0"
       style={{ maxWidth: 800, margin: "0 auto" }}
     >
       <div className="space-y-8">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,7 +65,7 @@ function FirstHero() {
         </div>
 
         <div
-          className="flex p-16 md:pl-4 md:pr-28"
+          className="flex p-16 md:pl-4 md:pr-28 max-xs:transform max-xs:scale-75 max-xs:p-0"
           style={{ height: "70vh", maxHeight: 600, zIndex: 1 }}
           id="chatprop-host"
         >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,13 @@
 const colors = require("tailwindcss/colors");
+const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
+    screens: {
+      xs: "475px",
+      ...defaultTheme.screens,
+    },
     extend: {
       colors: {
         gray: {


### PR DESCRIPTION
This solves #139 

## Screenshots

<details><summary>Hero section</summary>
<table align="center">
  <tr>
    <th>Original</th>
    <th>Changed</th>
  </tr>
  <tr>
    <td>
      <img height="500" alt="original" src="https://user-images.githubusercontent.com/98076988/213901788-af293cd3-b4ac-41cf-b7ed-507dc1bca08d.png">
    </td>
    <td>
      <img height="500" alt="fixed" src="https://user-images.githubusercontent.com/98076988/213901787-f23de712-5991-45b7-8ebd-a91589df7667.png">
    </td>
  </tr>
</table>
</details>

<details><summary>Testimonials section</summary>
<table align="center">
  <tr>
    <th>Original</th>
    <th>Changed</th>
  </tr>
  <tr>
    <td>
      <img height="500" alt="original" src="https://user-images.githubusercontent.com/98076988/213902163-d7eb7720-f5cd-431c-95f4-8bcbe7abfd44.png">
    </td>
    <td>
      <img height="500" alt="fixed" src="https://user-images.githubusercontent.com/98076988/213902162-50404882-9927-46f7-83aa-5b77f35a4b7c.png">
    </td>
  </tr>
</table>
</details>

<details><summary>Miscellaneous section</summary>
<table align="center">
  <tr>
    <th>Original</th>
    <th>Changed</th>
  </tr>
  <tr>
    <td>
      <img height="500" alt="original" src="https://user-images.githubusercontent.com/98076988/213902179-d59462b0-96ee-4f13-bb53-7ffd7f2c2bb5.png">
    </td>
    <td>
      <img height="500" alt="fixed" src="https://user-images.githubusercontent.com/98076988/213902177-251534c5-b03e-4824-84dd-aec7c745df28.png">
    </td>
  </tr>
</table>
</details>

## Changes

- Added custom "xs" screen breakpoint to tailwind config
- On narrow screens:
  - Adjusted paddings and margins to fit more content
  - Chat component:
    - Scaled to 75%
  - Testimonial component:
    - Changed flex-direction to column
    - Centered avatar
  - Miscellaneous component:
    - Slightly decreased font-size

**NOTE:** Used "max-xs" prefixes instead of "xs". This ensures that the styles won't affect the desktop UI, which might be a better solution compared to using min-width breakpoints, given that the main focus of the website is desktop use.

**NOTE (2):** I've opened this single PR instead of multiple ones because all changes depend on the tailwind configuration, and I couldn't figure out a clean approach to creating stacked PRs on GitHub.