### PR TITLE
Fix Carousel centering

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -264,7 +264,7 @@ function Testimonials() {
   return (
     <Section
       className="p-6 md:p-12 bg-gray-800 max-xs:p-0"
-      style={{ maxWidth: 800, margin: "0 auto" }}
+      style={{ margin: "0 auto" }}
     >
       <div className="space-y-8">
         <h1 className="text-white text-5xl text-center p-6">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -88,6 +88,7 @@ button {
 
 .carousel {
   max-width: 800px;
+  margin: auto !important;
 }
 
 .slide {


### PR DESCRIPTION
## Description

There are currently a couple of issues with the Carousel component that can make it uncentered in the page:

- It overflows it's container when at max width.

- When it is shrunk due to page resizing, the .carrousel-root element can be wider than .carrousel.

## Screenshot

![chatterino-carousel](https://user-images.githubusercontent.com/98076988/214180211-87a4251a-9f8f-4087-b5f0-889d76670f51.png)

## Changes

- Removed max-width from the Section's styling to prevent overflow.
- Centered the .carousel element.