### PR TITLE
Added Shoutout Scope

### DIFF
--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -87,6 +87,9 @@ const scopes = [
   // https://dev.twitch.tv/docs/api/reference#get-shield-mode-status  
   // https://dev.twitch.tv/docs/api/reference#update-shield-mode-status 
   "moderator:manage:shield_mode", // for reading/managing the channel's shield-mode status/settings (not currently used)
+
+  // https://dev.twitch.tv/docs/api/reference/#send-a-shoutout
+  "moderator:manage:shoutouts", // for reading/managing the channel's shoutouts (not currently used)
 ];
 
 export default function ClientLogin() {


### PR DESCRIPTION
I just noticed yesterday that there is a beta API for sending Shoutouts and 2 EventSub Topics.
From my research it seems like you have to use the `moderator:manage:shoutouts` scope for the send a shoutout endpoint but you can optionally also use `moderator:read:shoutouts` for the EventSub Topics.

I just added the manage scope (I took the shield mode PR as template on how to) because I do not know if we really need  both because the manage seems to have all capabilities that the read scope has.

References:
[API Endpoint for sending a Shoutout](https://dev.twitch.tv/docs/api/reference/#send-a-shoutout)
[channel.shoutout.create EventSub subscription type](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelshoutoutcreate)
[channel.shoutout.receive EventSub subscription type](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelshoutoutreceive)