### PR TITLE
Remove deprecated IRC command scopes

### DIFF
--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -5,14 +5,11 @@ import Section from "../components/section";
 const redirectUrl = process.env.NEXT_PUBLIC_TWITCH_OAUTH_REDIRECT_URL!;
 const twitchClientID = process.env.NEXT_PUBLIC_TWITCH_OAUTH_CLIENT_ID!;
 const scopes = [
-  "channel_editor", // for /raid, will be deprecated on or before Feb 18th 2023, already using "channel:manage:raids"
   "channel:moderate", // for seeing automod & which moderator banned/unbanned a user (felanbird unbanned weeb123)
   "channel:read:redemptions", // for getting the list of channel point redemptions (not currently used)
   "chat:edit", // for sending messages in chat
   "chat:read", // for viewing messages in chat
   "whispers:read", // for viewing recieved whispers
-  "whispers:edit", // for sending whispers, will be deprecated on or before Feb 18th 2023, already using "user:manage:whispers"
-  "channel_commercial", // for /commercial, will be deprecated on or before Feb 18th 2023, already using "channel:edit:commercial"
 
   // https://dev.twitch.tv/docs/api/reference#start-commercial
   "channel:edit:commercial", // for /commercial api 


### PR DESCRIPTION
I noticed them when linking someone the scope list we request