### PR TITLE
Add dates to the changelog

### DIFF
--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -7,7 +7,7 @@ import Section from "components/section";
 
 # Chatterino Changelog
 
-## 2.4.2
+## 2.4.2 (Released 2023-03-06)
 
 *Note: This release fixes FFZ emotes since their API changed the URL format.*
 
@@ -19,7 +19,7 @@ import Section from "components/section";
 - Dev: Added capability to build Chatterino with Qt6. (#4393)
 - Dev: Fixed homebrew update action. (#4394)
 
-## 2.4.1
+## 2.4.1 (Released 2023-02-19)
 
 - Major: Added live emote updates for BTTV. (#4147)
 - Major: Fix some actions (e.g. banning) not working (see specific entries in Bugfix)
@@ -79,7 +79,7 @@ import Section from "components/section";
 - Dev: Use `QEnterEvent` for `QWidget::enterEvent` on Qt 6. (#4365)
 - Dev: Use `qintptr` in `QWidget::nativeEvent` on Qt 6. (#4376)
 
-## 2.4.0
+## 2.4.0 (Released 2022-11-28)
 
 - Major: Added support for emotes, badges, and live emote updates from [7TV](https://7tv.app). [Wiki Page](https://wiki.chatterino.com/Third_party_services/#7tv) (#4002, #4062, #4090)
 - Major: Added support for Right-to-Left Languages (#3958, #4139, #4168)
@@ -226,7 +226,7 @@ import Section from "components/section";
 - Dev: Automatically generate resources files with cmake. (#4159, #4167)
 
 
-## 2.3.5
+## 2.3.5 (Released 2022-04-05)
 
 - Major: Added highlights for first messages (#3267)
 - Major: Added customizable shortcuts. (#2340, #3633)
@@ -345,7 +345,7 @@ import Section from "components/section";
 - Dev: Updated PubSub client to use TLS v1.2 (#3599)
 - Dev: Use system logical core count for Ubuntu/macOS GitHub actions builds. (#3602)
  
-## 2.3.4
+## 2.3.4 (Released 2022-08-05)
 
 - Major: Fixed connection issues when joining 20+ channels. (#3112, #3115)
 - Major: Added support for twitch's new emote format. (#2992)
@@ -368,7 +368,7 @@ import Section from "components/section";
 - Dev: Add logging for HTTP requests (#2991)
 
 
-## 2.3.3
+## 2.3.3 (Released 2022-07-13)
 
 - Major: Added username autocompletion popup menu when typing usernames with an @ prefix. (#1979, #2866)
 - Major: Added ability to toggle visibility of Channel Tabs - This can be done by right-clicking the tab area or pressing the keyboard shortcut (default: Ctrl+U). (#2600)
@@ -406,7 +406,7 @@ import Section from "components/section";
 - Bugfix: Fixed bit and new subscriber emotes not (re)loading in some rare cases. (#2856, #2857)
 - Bugfix: Fixed subscription emotes showing up incorrectly in the emote menu. (#2905)
  
-## 2.3.2
+## 2.3.2 (Released 2021-05-16)
 
 - New split for channels going live. (#1797)
 - Minor: Added a message that displays a new date on new day. (#1016)
@@ -424,7 +424,7 @@ import Section from "components/section";
 - Dev: Migrated AutoMod approve/deny endpoints to Helix. (#2779)
 - Dev: Migrated Get Cheermotes endpoint to Helix. (#2440)
 
-## 2.3.1
+## 2.3.1 (Released 2021-05-03)
 
 - Fixed crashing when the extension is active. (#2704)
 - Added the ability to highlight messages based on user badges. (#1704)
@@ -446,7 +446,7 @@ import Section from "components/section";
 
 </div>
 
-## 2.3
+## 2.3.0 (Released 2021-04-17)
 
 - Added "Channel Filters". See https://wiki.chatterino.com/Filters/ for more information. (#1748, #2083, #2090, #2200, #2225)
 - Added Streamer Mode configuration (under `Settings -> General`), where you can select which features of Chatterino should behave differently when you are in Streamer Mode. (#2001, #2316, #2342, #2376)
@@ -575,16 +575,16 @@ import Section from "components/section";
 
 </div>
 
-## 2.2.2-fix
+## 2.2.2-fix (Released 2020-11-17)
 
 - Fixed a crash related to channel point rewards.
 - Fixed crash related to debug asserts.
 
-## 2.2.1
+## 2.2.1 (Released 2020-08-24)
 
 - Small behaviour changes and fixes.
 
-## 2.2.0
+## 2.2.0 (Released 2020-08-23)
 
 - Major: Emotes can now be completed by typing : in chat.
 
@@ -612,19 +612,19 @@ import Section from "components/section";
 
 - "Online Logs" has been removed as services have shut down.
 
-## 2.1.7
+## 2.1.7 (Released 2019-12-29)
 
 - Fixed a bug that made tooltips gain focus on windows.
 
 - Replaced the link parser with a custom one.
 
-## 2.1.6
+## 2.1.6 (Released 2019-12-27)
 
 - Fixed a bug that caused Chatterino to hang when parsing long links.
 
 - Fixed bit amounts not stacking properly.
 
-## 2.1.5
+## 2.1.5 (Released 2019-10-05)
 
 - Added setting to restart Chatterino after a crash.
 
@@ -641,7 +641,7 @@ import Section from "components/section";
 
 - Added experimental support for IRC (available in settings).
 
-## 2.1.4
+## 2.1.4 (Released 2019-09-15)
 
 - Settings and logs can now be searched!
 
@@ -659,7 +659,7 @@ import Section from "components/section";
 
 - Ctrl+C now copies text in the search popup.
 
-## 2.1.3
+## 2.1.3 (Released 2019-08-02)
 
 - Added settings for beta updates.
 
@@ -675,11 +675,11 @@ import Section from "components/section";
 
 - Added button to open AppData in the settings.
 
-## 2.1.2 (Hotfix)
+## 2.1.2 (Released 2019-07-27)
 
 - Fixed maximized and minimized windows not saving properly.
 
-## 2.1.1
+## 2.1.1 (Released 2019-07-26)
 
 - Fixed crash when removing accounts.
 
@@ -704,7 +704,7 @@ import Section from "components/section";
 
   - Update has been deployed in chrome and firefox webstores.
 
-## 2.1.0
+## 2.1.0 (Released 2019-07-19)
 
 - Major: Added support for viewing users logs from
 
@@ -768,12 +768,12 @@ import Section from "components/section";
   break the extension.
   <by>fourtf</by>
 
-## 2.0.4 (Hotfix)
+## 2.0.4 (Released 2018-06-28)
 
 - Fixed crash on windows 7 and 8
   <by>fourtf</by>
 
-## 2.0.3 (Hotfix)
+## 2.0.3 (Released 2018-06-28)
 
 - Fixed scaling of 150% or more.
 
@@ -782,7 +782,7 @@ import Section from "components/section";
 - Fixed issue where the window size is wrong on startup.
   <by>fourtf</by>
 
-## 2.0.2
+## 2.0.2 (Released 2018-06-25)
 
 - - Fixed sometimes not being able to send messages.
     <by>fourtf</by>
@@ -813,7 +813,7 @@ import Section from "components/section";
 
   <by>pajlada</by>
 
-## 2.0.1
+## 2.0.1 (Released 2018-06-24)
 
 - - Added support for the Chatterino browser extension.
     <by>fourtf</by>
@@ -844,8 +844,10 @@ import Section from "components/section";
 
   <by>hemirt</by>
 
-## 2.0.0
+## 2.0.0 (Released 2018-06-23)
 
 - Initial release on windows.
 
 </Section>
+
+<br /><br />


### PR DESCRIPTION
Older ones are takes either from the GitHub Release date or from my own copies. Generally they should only differ by a week max.