### PR TITLE
Update website for v2.4.4 release

### DIFF
--- a/links.ts
+++ b/links.ts
@@ -9,7 +9,7 @@ export const nightly =
   "https://github.com/Chatterino/chatterino2/releases/tag/nightly-build";
 export const allDownloads = "download";
 
-const currentVersion = "2.4.2";
+const currentVersion = "2.4.3";
 export const baseDownloadLink = `https://chatterino.fra1.digitaloceanspaces.com/bin`;
 const dl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${currentVersion}`;
 
@@ -32,7 +32,8 @@ export const allVersions = [
   "2.3.5",
   "2.4.0",
   "2.4.1",
-  "2.4.2"
+  "2.4.2",
+  "2.4.3",
 ];
 export const allV1Versions = [
   "0.2.6.4",

--- a/links.ts
+++ b/links.ts
@@ -9,7 +9,7 @@ export const nightly =
   "https://github.com/Chatterino/chatterino2/releases/tag/nightly-build";
 export const allDownloads = "download";
 
-const currentVersion = "2.4.3";
+const currentVersion = "2.4.4";
 export const baseDownloadLink = `https://chatterino.fra1.digitaloceanspaces.com/bin`;
 const dl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${currentVersion}`;
 
@@ -33,7 +33,7 @@ export const allVersions = [
   "2.4.0",
   "2.4.1",
   "2.4.2",
-  "2.4.3",
+  "2.4.4",
 ];
 export const allV1Versions = [
   "0.2.6.4",

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -7,7 +7,8 @@ import Section from "components/section";
 
 # Chatterino Changelog
 
-## 2.4.3 (Released 2023-04-30)
+## 2.4.3 (Released 2023-05-01)
+
 
 *Note: This release fixes Twitch viewer list not loading for moderators & badges not loading.*
 

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -20,7 +20,7 @@ import Section from "components/section";
 - Minor: Added better filter validation and error messages. (#4364)
 - Minor: Updated the look of the Black Theme to be more in line with the other themes. (#4523)
 - Minor: Re-added leading @mentions from replies in chat logs. These were accidentally removed during the reply overhaul. (#4420)
-- Minor: Updated the MacOS icon to match the look of other Mac Apps (#4577)
+- Minor: Updated the macOS icon to be consistent with the design of other applications on macOS. (#4577)
 - Bugfix: Fixed an issue where Chatterino could lose track of the sound device in certain scenarios. (#4549)
 - Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
 - Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -7,7 +7,7 @@ import Section from "components/section";
 
 # Chatterino Changelog
 
-## 2.4.3 (Released 2023-05-01)
+## 2.4.4 (Released 2023-05-03)
 
 
 *Note: This release fixes Twitch viewer list not loading for moderators & badges not loading.*

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -7,6 +7,34 @@ import Section from "components/section";
 
 # Chatterino Changelog
 
+## 2.4.3 (Released 2023-04-30)
+
+*Note: This release fixes Twitch viewer list not loading for moderators & badges not loading.*
+
+- Major: Added support for FrankerFaceZ animated emotes. (#4434)
+- Minor: Added the ability to reply to a message by `Shift + Right Click`ing the username. (#4424)
+- Minor: Reply context now censors blocked users. (#4502)
+- Minor: Migrated the viewer list to Helix API. (#4117)
+- Minor: Migrated badges to Helix API. (#4537)
+- Minor: Added `/lowtrust` command to open the suspicious user activity feed in browser. (#4542)
+- Minor: Added better filter validation and error messages. (#4364)
+- Minor: Updated the look of the Black Theme to be more in line with the other themes. (#4523)
+- Minor: Re-added leading @mentions from replies in chat logs. These were accidentally removed during the reply overhaul. (#4420)
+- Minor: Updated the MacOS icon to match the look of other Mac Apps (#4577)
+- Bugfix: Fixed an issue where Chatterino could lose track of the sound device in certain scenarios. (#4549)
+- Bugfix: Fixed an issue where animated emotes would render on top of zero-width emotes. (#4314)
+- Bugfix: Fixed an issue where it was difficult to hover a zero-width emote. (#4314)
+- Bugfix: Fixed an issue where context-menu items for zero-width emotes displayed the wrong provider. (#4460)
+- Bugfix: Fixed an issue where the "Enable zero-width emotes" setting was showing the inverse state. (#4462)
+- Bugfix: Fixed blocked user list being empty when opening the settings dialog for the first time. (#4437)
+- Bugfix: Fixed blocked user list sticking around when switching from a logged in user to being logged out. (#4437)
+- Bugfix: Fixed search popup ignoring setting for message scrollback limit. (#4496)
+- Bugfix: Fixed a memory leak that occurred when loading message history. This was mostly noticeable with unstable internet connections where reconnections were frequent or long-running instances of Chatterino. (#4499)
+- Bugfix: Fixed Twitch channel-specific filters not being applied correctly. (#4529)
+- Bugfix: Fixed `/mods` displaying incorrectly when the channel has no mods. (#4546)
+- Bugfix: Fixed emote & badge tooltips not showing up when thumbnails were hidden. (#4509)
+- Bugfix: Fixed disabled items in context-menus having a weird text-effect or the default text color. (#4423)
+
 ## 2.4.2 (Released 2023-03-06)
 
 *Note: This release fixes FFZ emotes since their API changed the URL format.*


### PR DESCRIPTION
Should only be merged in after https://github.com/Chatterino/chatterino2/pull/4584 and the release has been fully finalized (artifacts uploaded, api updated to include the new version)
