### PR TITLE
Remove 2.0.4-beta links from the website

### DIFF
--- a/links.ts
+++ b/links.ts
@@ -14,7 +14,6 @@ export const baseDownloadLink = `https://chatterino.fra1.digitaloceanspaces.com/
 const dl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${currentVersion}`;
 
 export const allVersions = [
-  "2.0.4-beta",
   "2.1.0",
   "2.1.4",
   "2.1.5-4",


### PR DESCRIPTION
This PR removes the links for version `2.0.4-beta` because the binaries are gone and we don't exactly have them laying around (nor do we really want people using versions from 2018)


Fixes #193