### PR TITLE
Add Ubuntu deb links & move AppImage down

### DIFF
--- a/links.ts
+++ b/links.ts
@@ -9,7 +9,7 @@ export const nightly =
   "https://github.com/Chatterino/chatterino2/releases/tag/nightly-build";
 export const allDownloads = "download";
 
-const currentVersion = "2.4.4";
+export const currentVersion = "2.4.4";
 export const baseDownloadLink = `https://chatterino.fra1.digitaloceanspaces.com/bin`;
 const dl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${currentVersion}`;
 

--- a/pages/linux.tsx
+++ b/pages/linux.tsx
@@ -3,26 +3,41 @@ import Section from "../components/section";
 import Link from "../components/link";
 import Text from "../components/text";
 import Page from "../components/page";
-import { linuxAppimageUrl, linuxBuildFromSource } from "../links";
+import {
+  currentVersion,
+  linuxAppimageUrl,
+  linuxBuildFromSource,
+} from "../links";
 
 function LinuxPage() {
+  const ubuntu2204Link = `https://github.com/Chatterino/chatterino2/releases/download/v${currentVersion}/Chatterino-Ubuntu-22.04.deb`;
+  const ubuntu2004Link = `https://github.com/Chatterino/chatterino2/releases/download/v${currentVersion}/Chatterino-Ubuntu-20.04.deb`;
   return (
     <Page title="Chatterino on Linux">
       <div className="p-16">
         <Section>
           <h1 className="text-5xl">Chatterino on Linux</h1>
-          {/* AppImage */}
-          <h2 className="text-3xl pt-10 pb-4">AppImage for all distros</h2>
+          {/* Ubuntu 22.04 */}
+          <h2 className="text-3xl pt-10 pb-4">
+            Ubuntu 22.04 (Jammy Jellyfish)
+          </h2>
           <Text>
-            You can install an AppImage with all dependencies bundled in a
-            single executable. Run this script in a terminal to install:
-            <div className="p-4 mt-4 bg-gray-900 border-gray-600 border">
-              <pre>cd /usr/local/bin</pre>
-              <pre>
-                sudo bash -c "curl {linuxAppimageUrl} &gt; ./chatterino"
-              </pre>
-              <pre>sudo chmod +x ./chatterino</pre>
-            </div>
+            A .deb file is available from{" "}
+            <Link href={ubuntu2204Link}>here</Link>.
+          </Text>
+          <Text>
+            The Universe repository must be enabled for it to download the
+            relevant dependencies.
+          </Text>
+          {/* Ubuntu 20.04 */}
+          <h2 className="text-3xl pt-10 pb-4">Ubuntu 20.04 (Focal Fossa)</h2>
+          <Text>
+            A .deb file is available from{" "}
+            <Link href={ubuntu2004Link}>here</Link>.
+          </Text>
+          <Text>
+            The Universe repository must be enabled for it to download the
+            relevant dependencies.
           </Text>
           {/* Flatpak */}
           <h2 className="text-3xl pt-10 pb-4">Flatpak</h2>
@@ -53,6 +68,19 @@ function LinuxPage() {
               dnf install chatterino2
             </code>{" "}
             to install it from the ports tree.
+          </Text>
+          {/* AppImage */}
+          <h2 className="text-3xl pt-10 pb-4">AppImage for all distros</h2>
+          <Text>
+            You can install an AppImage with all dependencies bundled in a
+            single executable. Run this script in a terminal to install:
+            <div className="p-4 mt-4 bg-gray-900 border-gray-600 border">
+              <pre>cd /usr/local/bin</pre>
+              <pre>
+                sudo bash -c "curl {linuxAppimageUrl} &gt; ./chatterino"
+              </pre>
+              <pre>sudo chmod +x ./chatterino</pre>
+            </div>
           </Text>
           {/* Building from Source */}
           <h2 className="text-3xl pt-10 pb-4">Building from Source</h2>


### PR DESCRIPTION
Fixes #208

We link to the GitHub release here

AppImage portion was moved down where it belongs

![image](https://github.com/Chatterino/website/assets/962989/be36f39f-6ffe-4940-9bff-756f7ae4d38b)
