### PR TITLE
Release v2.4.6 (Windows only)

### DIFF
--- a/links.ts
+++ b/links.ts
@@ -10,8 +10,10 @@ export const nightly =
 export const allDownloads = "download";
 
 export const currentVersion = "2.4.5";
+export const windowsVersion = "2.4.6";
 export const baseDownloadLink = `https://chatterino.fra1.digitaloceanspaces.com/bin`;
 const dl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${currentVersion}`;
+const windowsDl = `https://chatterino.fra1.digitaloceanspaces.com/bin/${windowsVersion}`;
 
 export const allVersions = [
   "2.1.0",
@@ -35,6 +37,7 @@ export const allVersions = [
   "2.4.3",
   "2.4.4",
   "2.4.5",
+  "2.4.6",
 ];
 export const allV1Versions = [
   "0.2.6.4",
@@ -56,13 +59,13 @@ export const allV1Versions = [
 export type DownloadType = [() => JSX.Element, string, string];
 export const windows: DownloadType = [
   Windows,
-  `${currentVersion} for Windows 64-Bit`,
-  `${dl}/Chatterino%20Installer.exe`,
+  `${windowsVersion} for Windows 64-Bit`,
+  `${windowsDl}/Chatterino%20Installer.exe`,
 ];
 export const linux: DownloadType = [Tux, "Linux", "linux"];
 export const freeBsd: DownloadType = [FreeBSD, "FreeBSD", "freebsd"];
 export const macOs: DownloadType = [Apple, "macOS", `${dl}/Chatterino.dmg`];
-export const windowsPortable = `${dl}/Chatterino%20Portable.zip`;
+export const windowsPortable = `${windowsDl}/Chatterino%20Portable.zip`;
 export const linuxAppimageUrl = `${dl}/Chatterino-x86_64.AppImage`;
 
 export const linuxBuildFromSource =

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -7,6 +7,18 @@ import Section from "components/section";
 
 # Chatterino Changelog
 
+## 2.4.6 (Released 2023-09-30)
+
+### **This is a Windows-only security release**
+
+This change brings a few less tested consequences, such as emote order being
+a bit different and some UI changes. These are being worked on for the next
+release.
+
+- Bugfix: Update Qt version from v5.15 to v6.5, fixing a [security issue with webp
+  loading](https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format). (#4844)
+- Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
+
 ## 2.4.5 (Released 2023-08-26)
 
 - Major: AutoMod term management messages (e.g. testaccount added "noob" as a blocked term on AutoMod.) are now hidden in Streamer Mode if you have the "Hide moderation actions" setting enabled. (#4758)


### PR DESCRIPTION
This release is a security release for Windows only

I haven't fixed anything in `download.tsx` so the download links to non-windows-builds there will be broken, but I don't want to make this PR too big.

The release can be found here https://github.com/Chatterino/chatterino2/releases/tag/v2.4.6
