### PR TITLE
Fix typos in `changelog.mdx`

### DIFF
--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -9,7 +9,7 @@ import Section from "components/section";
 
 ## 2.4.6 (Released 2023-09-30)
 
-This is a **security release** and currently **only available on Windows**. This release also **drops support for Window 7 and Windows 8** since we are required to update our dependencies which do not work with unsupported Windows releases anymore.
+This is a **security release** and currently **only available on Windows**. This release also **drops support for Windows 7 and Windows 8** since we are required to update our dependencies which do not work with unsupported Windows releases anymore.
 
 <br />
 
@@ -17,8 +17,7 @@ This change brings a few less tested consequences, such as emote order being
 a bit different and some UI changes. These are being worked on for the next
 release.
 
-- Bugfix: Fix a [security issue when loading webp image files
-  loading](https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format). To achieve this, Qt was updated from 5.15 to 6.5. (#4844)
+- Bugfix: Fix a [security issue when loading webp image files loading](https://www.qt.io/blog/two-qt-security-advisorys-gdi-font-engine-webp-image-format). To achieve this, Qt was updated from 5.15 to 6.5. (#4844)
 - Minor: Support for Windows 7 and Windows 8 was discontinued to keep up with the above-mentioned security fixes as well as future ones.
 - Minor: Migrate to the new Get Channel Followers Helix endpoint, fixing follower count not showing up in usercards. (#4809)
 


### PR DESCRIPTION
This PR includes a fix for a typo I noticed (Window 7) and something Felanbird noticed and mentioned in pajlada's Twitch Channel at 00:23:15, 00:23:44 and 00:23:48 germany time.