### PR TITLE
Add user:chat:read scope

### DIFF
--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -9,6 +9,7 @@ const scopes = [
   "channel:read:redemptions", // for getting the list of channel point redemptions (not currently used)
   "chat:edit", // for sending messages in chat
   "chat:read", // for viewing messages in chat
+  "user:chat:read", // for viewing messages in chat (+ eventsub?)
   "whispers:read", // for viewing recieved whispers
 
   // https://dev.twitch.tv/docs/api/reference#start-commercial


### PR DESCRIPTION
This is required for some EventSub subscriptions. I tested this by manually adding the scope to the chatterino login page, and everything works as expected.
