### PR TITLE
chore(login): request moderated channels scope

### DIFF
--- a/pages/client_login.tsx
+++ b/pages/client_login.tsx
@@ -88,6 +88,9 @@ const scopes = [
 
   // https://dev.twitch.tv/docs/api/reference/#send-a-shoutout
   "moderator:manage:shoutouts", // for reading/managing the channel's shoutouts (not currently used)
+
+  // https://dev.twitch.tv/docs/api/reference/#get-moderated-channels
+  "user:read:moderated_channels", // for reading where the user is modded (not currently used)
 ];
 
 export default function ClientLogin() {


### PR DESCRIPTION
Useful if we switch to anon irc read connections or eventsub chat (as these approaches don't deliver `USERSTATE` with mod status information)

Alternatively, could be used (by a plugin?) to provide a handy button to join all channels that the user moderates