### PR TITLE
fix: use local time in chat component

### DIFF
--- a/components/chat/common.js
+++ b/components/chat/common.js
@@ -54,7 +54,9 @@ const Chatters = [
 ];
 
 const TimeFormatter = new Intl.DateTimeFormat(undefined, {
-  timeStyle: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
 });
 
 /**

--- a/components/chat/common.js
+++ b/components/chat/common.js
@@ -53,6 +53,10 @@ const Chatters = [
   "WgXcQ",
 ];
 
+const TimeFormatter = new Intl.DateTimeFormat(undefined, {
+  timeStyle: "short",
+});
+
 /**
  * @template T
  * @param {T[]} array
@@ -83,9 +87,7 @@ export function tabTitle(tab) {
 
 /** @param {Date} time */
 export function formatTime(time) {
-  const hours = time.getUTCHours();
-  const minutes = time.getUTCMinutes();
-  return `${hours}:${minutes}`;
+  return TimeFormatter.format(time);
 }
 
 /**


### PR DESCRIPTION
Uses `Intl.DateTimeFormatter` to format the local time. Previously, the UTC time was displayed.