### PR TITLE
Revert "Add note about Flathub branches on the Linux install page"

### DIFF
--- a/pages/linux.tsx
+++ b/pages/linux.tsx
@@ -48,15 +48,8 @@ function LinuxPage() {
             </Link>
             . To install it run:{" "}
             <code className="p-1 px-2 mt-4 border-gray-600 border bg-gray-900">
-              flatpak install com.chatterino.chatterino/x86_64/stable
+              flatpak install chatterino
             </code>{" "}
-            <Text>
-              Note: the "nightly" branch on Flathub is currently not up to date.
-            </Text>
-            <Text>
-              Installing via CLI is preferred as GUI package managers might use
-              the outdated branch.
-            </Text>
           </Text>
           {/* AUR */}
           <h2 className="text-3xl pt-10 pb-4">Arch Linux</h2>


### PR DESCRIPTION
Now that https://github.com/flathub/flathub/issues/4767 is finally resolved, the note that was added in #631 should be removed.