### PR TITLE
chore: misc changes to the changelog

### DIFF
--- a/components/figure-group.tsx
+++ b/components/figure-group.tsx
@@ -5,5 +5,9 @@ export default function FigureGroup({
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="flex gap-4 justify-left flex-wrap">{children}</div>;
+  return (
+    <div className="flex my-4 gap-x-4 gap-y-6 justify-left flex-wrap figure-group">
+      {children}
+    </div>
+  );
 }

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -125,7 +125,7 @@ your distro already runs something).
 
 - Channels that are visible are now joined first. <Credit author="Nerixyz" prs="5850" inline />
 
-- You can now allow other extensions to interact with Chatterino. <Credit author="MiguVT" prs="5997" inline />
+- You can now allow other browser extensions to interact with Chatterino. <Credit author="MiguVT" prs="5997" inline />
 
 - Added `Set highlight sounds` and `Open subscription page` hotkeys. <Credit author="brian6932" prs="5856, 6030" inline />
 
@@ -211,15 +211,12 @@ your distro already runs something).
 
 <div className="changelog-entry">
 
-This release does _not_ support Qt5, meaning if you're on Windows 7 you won't
-be able to run this. Please update your operating system.
-
-<br />
-
-A WEBP support check is run on startup. If your system doesn't support webp
-for whatever reason (e.g. packaging has gone wrong), you'll see a warning
-popup. Feel free to reach out if you need help figuring out why this is
-showing up for you.
+- From this release onwards, Qt 5 is no longer supported, meaning if you're on Windows 7 or 8 you won't
+  be able to run this. Please update your operating system.
+- A WEBP support check is run on startup. If your system doesn't support WEBP
+  for whatever reason (e.g. packaging has gone wrong), you'll see a warning
+  popup. Feel free to reach out if you need help figuring out why this is
+  showing up for you.
 
 </div>
 

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -58,7 +58,7 @@ href={github}>GitHub</a>.
 
 Fixes various crashes that could occur when:
 
-- making a Lua HTTP request
+- making a Lua HTTP request from a coroutine
 - clicking the "Install" button for an update on Linux or macOS
 - closing down Chatterino
 - trying to search in an uninitialized split
@@ -187,7 +187,7 @@ your distro already runs something).
 
 - Hotkeys and their keybinds are now searchable. <Credit author="apa420" prs="5884" inline />
 
-- Overlay windows now inherit the global zoom level and can be zoomed independently. <Credit author="Nerixyz" prs="6016" inline />
+- Overlay windows can now be zoomed independently (by default: <kbd>CTRL</kbd>+<kbd>+</kbd>/<kbd>-</kbd>). <Credit author="Nerixyz" prs="6016" inline />
 
 - The `/watching` channel is now supported on all platforms. <Credit author="Nerixyz" prs="6031, 6043" inline />
 

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -119,6 +119,46 @@ your distro already runs something).
 
 </div>
 
+### Miscellaneous changes {#2.5.3-miscellaneous-changes}
+
+<div className="changelog-entry">
+
+- Channels that are visible are now joined first. <Credit author="Nerixyz" prs="5850" inline />
+
+- You can now allow other extensions to interact with Chatterino. <Credit author="MiguVT" prs="5997" inline />
+
+- Added `Set highlight sounds` and `Open subscription page` hotkeys. <Credit author="brian6932" prs="5856, 6030" inline />
+
+- `/clear` messages now stack like timeouts. <Credit author="Nerixyz" prs="5806" inline />
+
+- Updated browser list for incognito browser support. <Credit author="teknsl, Wissididom" prs="5805, 5810" inline />
+
+- Improved error messaging of the `/clip` command. <Credit author="pajlada" prs="5879" inline />
+
+- Clicking on a live notification can now open the channel in a custom player. (#5880)
+
+- Hotkeys and their keybinds are now searchable. <Credit author="apa420" prs="5884" inline />
+
+- Overlay windows can now be zoomed independently (by default: <kbd>CTRL</kbd>+<kbd>+</kbd>/<kbd>-</kbd>). <Credit author="Nerixyz" prs="6016" inline />
+
+- The `/watching` channel is now supported on all platforms. <Credit author="Nerixyz" prs="6031, 6043" inline />
+
+- You can now customize the font weight of chat messages. <Credit author="Nerixyz" prs="6037" inline />
+
+- Added the ability to filter on messages by the author's user ID. <Credit author="apa420" prs="5862" inline />
+
+  Example filter: `author.user_id == "22484632"`
+
+- Messages can now be deleted by right-clicking them. <Credit author="Nerixyz" prs="5956" inline />
+
+- Messages from restricted users are now hidden in streamer mode. <Credit author="pajlada" prs="6042, 6049" inline />
+
+  You can disable this in settings.
+
+- Linux & macOS now cleanly handle SIGINT/SIGTERM signals. <Credit author="pajlada" prs="6053" inline />
+
+</div>
+
 ### Miscellaneous fixes {#2.5.3-miscellaneous-fixes}
 
 <div className="changelog-entry">
@@ -164,46 +204,6 @@ your distro already runs something).
 - The emote button no longer looks crunchy. <Credit author="pajlada" prs="6080" inline />
 
 - Fixed a potential way to escape the Lua Plugin sandbox. <Credit author="Mm2pl" prs="5846" inline />
-
-</div>
-
-### Miscellaneous changes {#2.5.3-miscellaneous-changes}
-
-<div className="changelog-entry">
-
-- Channels that are visible are now joined first. <Credit author="Nerixyz" prs="5850" inline />
-
-- You can now allow other extensions to interact with Chatterino. <Credit author="MiguVT" prs="5997" inline />
-
-- Added `Set highlight sounds` and `Open subscription page` hotkeys. <Credit author="brian6932" prs="5856, 6030" inline />
-
-- `/clear` messages now stack like timeouts. <Credit author="Nerixyz" prs="5806" inline />
-
-- Updated browser list for incognito browser support. <Credit author="teknsl, Wissididom" prs="5805, 5810" inline />
-
-- Improved error messaging of the `/clip` command. <Credit author="pajlada" prs="5879" inline />
-
-- Clicking on a live notification can now open the channel in a custom player. (#5880)
-
-- Hotkeys and their keybinds are now searchable. <Credit author="apa420" prs="5884" inline />
-
-- Overlay windows can now be zoomed independently (by default: <kbd>CTRL</kbd>+<kbd>+</kbd>/<kbd>-</kbd>). <Credit author="Nerixyz" prs="6016" inline />
-
-- The `/watching` channel is now supported on all platforms. <Credit author="Nerixyz" prs="6031, 6043" inline />
-
-- You can now customize the font weight of chat messages. <Credit author="Nerixyz" prs="6037" inline />
-
-- Added the ability to filter on messages by the author's user ID. <Credit author="apa420" prs="5862" inline />
-
-  Example filter: `author.user_id == "22484632"`
-
-- Messages can now be deleted by right-clicking them. <Credit author="Nerixyz" prs="5956" inline />
-
-- Messages from restricted users are now hidden in streamer mode. <Credit author="pajlada" prs="6042, 6049" inline />
-
-  You can disable this in settings.
-
-- Linux & macOS now cleanly handle SIGINT/SIGTERM signals. <Credit author="pajlada" prs="6053" inline />
 
 </div>
 

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -23,7 +23,7 @@ import { discord, github } from "../links";
 <div className="changelog-entry">
 
 Twitch is shutting down the old API we used to get moderation events & channel
-point events from. In this release, we've updated to Twitch's new API
+point events from in the middle of April. In this release, we've updated to Twitch's new API
 [EventSub](https://dev.twitch.tv/docs/eventsub/).
 
 This change has one known drawback:

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -89,8 +89,12 @@
     @apply flex flex-col items-start my-4;
   }
 
+  .changelog .figure-group figure {
+    @apply my-0;
+  }
+
   .changelog figcaption {
-    @apply my-4 max-w-96 text-gray-300 italic text-center;
+    @apply mt-2 max-w-96 text-gray-300 italic text-center;
   }
 
   .changelog code {


### PR DESCRIPTION
- Reduce spacing in figures (the author attribution had more space above than below)
- Mention that PubSub ends in mid april
- Chatterino could crash if a request was made _from a coroutine_ (or interacted with it).
- Misc changes are more important than fixes
- Mention that Qt 5 will no longer be supported
- Turn last paragraph into a list like the other entries