### PR TITLE
fix: use `font-display: swap`

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -127,6 +127,7 @@
 @font-face {
   font-family: "Noto Sans";
   src: url("../fonts/NotoSans-Regular.ttf");
+  font-display: swap;
 }
 
 html,


### PR DESCRIPTION
Sometimes, just the text on the Chatterino website takes long to load (probably when it's not cached). We can use `font-display: swap` to use a fallback font sooner.
See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display).

Epic GitHub-Web commit.