### PR TITLE
chore: use callout/admonition for notes

### DIFF
--- a/components/callout.tsx
+++ b/components/callout.tsx
@@ -1,0 +1,61 @@
+import { ReactNode } from "react";
+
+type CalloutType = "note" | "warning";
+type Props = {
+  type: "note";
+  children: ReactNode;
+};
+
+function configFor(type: CalloutType): {
+  title: string;
+  borderColor: string;
+  textColor: string;
+  icon: ReactNode;
+} {
+  switch (type) {
+    case "note":
+      return {
+        title: "Note",
+        borderColor: "border-blue-500",
+        textColor: "text-blue-500",
+        icon: (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+          </svg>
+        ),
+      };
+    case "warning":
+      return {
+        title: "Warning",
+        borderColor: "border-orange-500",
+        textColor: "text-orange-500",
+        icon: (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M12,2L1,21H23M12,6L19.53,19H4.47M11,10V14H13V10M11,16V18H13V16" />
+          </svg>
+        ),
+      };
+  }
+}
+
+export default function Callout({ type, children }: Props) {
+  const { title, borderColor, textColor, icon } = configFor(type);
+  return (
+    <div className={"border-l-4 px-3 py-1 my-4 " + borderColor}>
+      <div className={"inline-flex gap-2 " + textColor}>
+        {icon} {title}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Nav from "../components/nav";
 import Section from "../components/section";
 import Figure from "../components/figure";
+import Callout from "../components/callout";
 import FigureGroup from "../components/figure-group";
 import Credit, { GitHubUser } from "../components/credit";
 import { discord, github } from "../links";
@@ -88,10 +89,12 @@ Examples:
  - End the poll, preventing further votes from coming in and showing some poll information in chat:  
  `/endpoll`
 
-Note: This is only available for streamers, not moderators. If you would like
-moderators to be able to do this please see <a
-href="https://twitch.uservoice.com/forums/310213-developers/suggestions/43347684-allow-channel-moderators-to-control-polls-predicti">this
-Twitch UserVoice</a>.
+{/* prettier-ignore */}
+<Callout type="note">
+  This is only available for streamers, not moderators. If you would like
+  moderators to be able to do this please see
+  <a href="https://twitch.uservoice.com/forums/310213-developers/suggestions/43347684-allow-channel-moderators-to-control-polls-predicti">this Twitch UserVoice</a>.
+</Callout>
 
 <Credit
   author="iProdigy"
@@ -117,10 +120,12 @@ Examples:
  - Complete the prediction, declaring a winner:  
  `/completeprediction --choice "rust"`
 
-Note: This is only available for streamers, not moderators. If you would like
-moderators to be able to do this please see <a
-href="https://twitch.uservoice.com/forums/310213-developers/suggestions/43347684-allow-channel-moderators-to-control-polls-predicti">this
-Twitch UserVoice</a>.
+{/* prettier-ignore */}
+<Callout type="note">
+  This is only available for streamers, not moderators. If you would like
+  moderators to be able to do this please see
+  <a href="https://twitch.uservoice.com/forums/310213-developers/suggestions/43347684-allow-channel-moderators-to-control-polls-predicti">this Twitch UserVoice</a>.
+</Callout>
 
 <Credit
   author="iProdigy"


### PR DESCRIPTION
This makes them look similar to the GitHub callouts:

> [!NOTE]
> Like this

I added `note` and `warning`, though only `note` is used right now.