### PR TITLE
fix(changelog): only add padding if enough space is available

### DIFF
--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -13,7 +13,7 @@ import { discord, github } from "../links";
 
 <Nav />
 
- <Section className="changelog px-16" prose>
+ <Section className="changelog sm:px-16" prose>
 
 # Chatterino Changelog
 


### PR DESCRIPTION
This removes the padding if the screen is too small (or: it only adds padding if the width is >=640px). Intended to improve the mobile experience.