### PR TITLE
changelog: correct PR for dropping AppImage in 2.5.5

### DIFF
--- a/pages/changelog.mdx
+++ b/pages/changelog.mdx
@@ -393,7 +393,7 @@ Various changes made to the stability of Chatterino.
 
 - The oldest supported Qt version is now `6.7.1`. This likely only impacts macOS older than 10.15 which is no longer supported. <Credit author="pajlada" prs="6628" inline />
 - We no longer support Ubuntu 20.04. <Credit author="pajlada" prs="6630" inline />
-- We no longer support AppImage builds. <Credit author="pajlada" prs="6630" inline />
+- We no longer support AppImage builds. <Credit author="pajlada" prs="6504" inline />
 - Added a CMake option `CHATTERINO_EXTRA_BUILD_STRING` which allows the packager to provide an optional freestanding Qt-HTML string that shows up in the About page under the Chatterino version. <Credit author="pajlada" prs="6766" inline />
 - Chatterino now requires C++23. <Credit author="pajlada" prs="6693" inline />
 - Nightly builds no longer use the `modes` file to know they are nightly, a new build option is used: `CHATTERINO_NIGHTLY_BUILD`. <Credit author="pajlada" prs="6798" inline />


### PR DESCRIPTION
The wrong PR was linked for "We no longer support AppImage builds" in the 2.5.5 release.